### PR TITLE
Update fee for Fast Pool and Fast Pool v2

### DIFF
--- a/apps/public-api/src/constants.ts
+++ b/apps/public-api/src/constants.ts
@@ -59,7 +59,7 @@ export const poxAddressToPool = {
     logo: "/logos/fastpool.webp",
     website: "https://fastpool.org",
     symbol: "STX",
-    fee: 0.05,
+    fee: 0.047,
     feeDisclosed: true,
   },
   bc1q7w0jpwwjyq48qhyecnuwazfqv56880q67pmtfc: {
@@ -68,7 +68,7 @@ export const poxAddressToPool = {
     logo: "/logos/fastpool.webp",
     website: "https://fastpool.org",
     symbol: "STX",
-    fee: 0.05,
+    fee: 0.047,
     feeDisclosed: true,
   },
   bc1qs33quxgnwkrspgu82lmaczw7gtcfa88pll8fqm: {


### PR DESCRIPTION
Fees are and were in the past 4.7% or less.

Actually, it is 4.5% on the BTC rewards, but 4.7% (or less) is communicated on the stacks rewards. There is so much to fiddle and make it hard to compare for the user.